### PR TITLE
feat: Update template to use FLUX.1-dev model

### DIFF
--- a/inferless.yaml
+++ b/inferless.yaml
@@ -1,7 +1,7 @@
 # Inferless config file (version: 2.0.0)
 version: 2.0.0
 
-name: flux-1-schnell
+name: flux-1-dev
 import_source: LOCAL
 
 # you can choose the options between ONNX, TENSORFLOW, PYTORCH, Only applicable for FILE type import.


### PR DESCRIPTION
This commit modifies the Inferless template to run the black-forest-labs/FLUX.1-dev model instead of FLUX.1-schnell.

Changes include:
- Updated model_id in app.py to "black-forest-labs/FLUX.1-dev".
- Enabled model CPU offloading in app.py for better VRAM management.
- Adjusted default inference parameters (height, width, guidance_scale, num_inference_steps, max_sequence_length) in app.py to align with FLUX.1-dev recommendations.
- Added an optional seed parameter to app.py for reproducible image generation.
- Updated the 'name' field in inferless.yaml to "flux-1-dev".
- Reviewed inferless-runtime-config.yaml; current dependencies are expected to be compatible.